### PR TITLE
Remove restriction on past end dates in client contract validation


### DIFF
--- a/src/modules/admin/clients/schemas/ClientValidationSchema.tsx
+++ b/src/modules/admin/clients/schemas/ClientValidationSchema.tsx
@@ -5,7 +5,7 @@ dayjs.extend(isSameOrBefore);
 import { typeOptions, taxIdTypeOptions, contractTypeOptions, contractStatusOptions, AccessTypeDMB, StatusDMB } from '@/constants/backend.enums';
 import 'dayjs/plugin/isSameOrBefore';
 
-import { oneOfOptions, transformDate, isValidDayjs, isNotEmpty, isFutureDate } from '@/lib/zod.util';
+import { oneOfOptions, transformDate, isValidDayjs, isNotEmpty } from '@/lib/zod.util';
 
 // 📦 Utilidad para evitar repetir lógica
 const isEmpty = (val?: string | null) => !val?.trim();

--- a/src/modules/admin/clients/schemas/ClientValidationSchema.tsx
+++ b/src/modules/admin/clients/schemas/ClientValidationSchema.tsx
@@ -104,7 +104,13 @@ export const ClientValidationSchema = BaseSchema.superRefine((data, ctx) => {
         code: z.ZodIssueCode.custom,
         message: 'End date is required or invalid',
       });
-    } else if (!contract.startDate || !contract.startDate.isValid() || !contract.endDate.isAfter(contract.startDate)) {
+    } else if (!contract.startDate || !contract.startDate.isValid()) {
+      ctx.addIssue({
+        path: ['contract', 'endDate'],
+        code: z.ZodIssueCode.custom,
+        message: 'Valid start date is required to validate end date',
+      });
+    } else if (!contract.endDate.isAfter(contract.startDate)) {
       ctx.addIssue({
         path: ['contract', 'endDate'],
         code: z.ZodIssueCode.custom,

--- a/src/modules/admin/clients/schemas/ClientValidationSchema.tsx
+++ b/src/modules/admin/clients/schemas/ClientValidationSchema.tsx
@@ -110,12 +110,6 @@ export const ClientValidationSchema = BaseSchema.superRefine((data, ctx) => {
         code: z.ZodIssueCode.custom,
         message: 'End date must be at least one day after start date',
       });
-    } else if (!isFutureDate(contract.endDate)) {
-      ctx.addIssue({
-        path: ['contract', 'endDate'],
-        code: z.ZodIssueCode.custom,
-        message: 'End date cannot be in the past',
-      });
     }
   }
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Removed validation preventing past end dates in client contracts

- Now allows end dates to be in the past if other conditions are met


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ClientValidationSchema.tsx</strong><dd><code>Allow past end dates in client contract validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/admin/clients/schemas/ClientValidationSchema.tsx

<li>Deleted check that blocked end dates in the past<br> <li> Simplified contract end date validation logic


</details>


  </td>
  <td><a href="https://github.com/cordobamusicgroup/frontend-vite/pull/6/files#diff-bb1d93edff7c805c81a56742112c928d4c391a41f609ae235350a476ddf20403">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>