### PR TITLE
Refactor ListClientsTable: Rename clientStatus to status for API consistency


### DIFF
--- a/src/modules/admin/clients/components/organisms/ListClientsTable.tsx
+++ b/src/modules/admin/clients/components/organisms/ListClientsTable.tsx
@@ -152,7 +152,7 @@ const ListClientsTable: React.FC<ClientTableProps> = () => {
       dmb: apiData.dmb, // objeto dmb con accessType, subclientName y status
       balanceUsd: apiData.balances?.find((b: any) => b.currency === 'USD')?.amount ?? 0,
       balanceEur: apiData.balances?.find((b: any) => b.currency === 'EUR')?.amount ?? 0,
-      clientStatus: apiData.clientStatus, // nuevo campo desde la API
+      status: apiData.status, // nuevo campo desde la API
     })) || [];
 
   const defaultColDef: ColDef = {


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Renamed `clientStatus` to `status` in `ListClientsTable` for consistency

- Updated mapping to align with API response field names


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ListClientsTable.tsx</strong><dd><code>Rename clientStatus to status in client table mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/modules/admin/clients/components/organisms/ListClientsTable.tsx

<li>Changed mapped property from <code>clientStatus</code> to <code>status</code><br> <li> Ensured field name matches API response for consistency


</details>


  </td>
  <td><a href="https://github.com/cordobamusicgroup/frontend-vite/pull/14/files#diff-f1740e6e242ab8389e814627be38e639f4f788656154545cd11217e3149bb1be">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>